### PR TITLE
Exclude lib directory

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,5 +27,5 @@ markdown: kramdown
 theme: minima
 paginate: 5
 paginate_path: "/blog/page:num/" 
-exclude: ["less","node_modules","Gruntfile.js","package.json","README.md", "vendor", "Gemfile", "Gemfile.lock", "bundle", ".bundle"]
+exclude: ["less","node_modules","Gruntfile.js","package.json","README.md", "vendor", "Gemfile", "Gemfile.lock", "bundle", ".bundle", "lib"]
 


### PR DESCRIPTION
By default Jekyll will try to make this directory part of the site. It
should not.

This fixes the problem that our Navbar currently looks like this

<img width="455" alt="screenshot 2017-10-13 13 21 52" src="https://user-images.githubusercontent.com/12144/31560358-916f1032-b019-11e7-9578-82737d9c79da.png">
