### PR TITLE
Display the name of a blog post author

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-By: {{ page.author }}
+<p>By: {{ page.author }}</p>
 
 <hr />
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,6 +2,10 @@
 layout: default
 ---
 
+By: {{ page.author }}
+
+<hr />
+
 <article>
   {{ content | replace: '<!--break-->', '<a class="anchor" id="read-more"></a>' }}
 </article>


### PR DESCRIPTION
No reason to hide who wrote a blog post.

The HR is purely for looks and could probably be better handled with a
HTML element. Looking at:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article

I think the page structure should be more like

```html
<article>
  <header>
    <h1>Blog Post Title</h1>
    <h2>Blog Post Subtitle (optional)</h2>
    <address>By: Blog Post Author</address>
  </header>
  {{ blog post content }}
</article>
```

But I wanted to run that past Jenn to see if I'm right. It's not an area
I know much about.