### PR TITLE
Blog UI tweaks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ repostiory: "umn-asr/umn-asr.github.io"
 excerpt_separator: <!--break-->
 markdown: kramdown
 theme: minima
-paginate: 5
+paginate: 10
 paginate_path: "/blog/page:num/" 
 exclude: ["less","node_modules","Gruntfile.js","package.json","README.md", "vendor", "Gemfile", "Gemfile.lock", "bundle", ".bundle", "lib"]
 

--- a/_includes/content.html
+++ b/_includes/content.html
@@ -1,11 +1,5 @@
 <div class="container">
 		<a name="main-content"></a>
-    <div class="jumbotron jumbotron" style="background-color:#000000">
-      <div class="container">
-        <h1 class="display-3 text-white">Academic Support Resources Custom Solutions</h1>
-        <p class='text-warning'>Making a Positive Difference in Students Lives</p>
-      </div>
-    </div>
     {% include navigation.html %}
 </div>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,4 +19,10 @@
 				<label class="umnhf" for="umnhf-h-sb">Submit search query</label>
 				<input class="umnhf" id="umnhf-h-sb" type="submit" value="">
 			</form>
+			<div class="jumbotron">
+				<div class="container">
+					<h1 class="display-3 text-white">Academic Support Resources Custom Solutions</h1>
+					<p class='text-warning'>Making a Positive Difference in Students Lives</p>
+				</div>
+			</div>
 		</header>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,21 +1,21 @@
 ---
 layout: blog
 title: Blog
-subtitle: It's a Blog
+subtitle: Where we write about our work
 ---
 
 {% for post in paginator.posts %}
 <div class="post-preview">
-    <a href="{{ post.url | prepend: site.baseurl }}">
         <h2 class="post-title">
+          <a href="{{ post.url | prepend: site.baseurl }}">
             {{ post.title }}
+          </a>
         </h2>
         {% if post.subtitle %}
         <h3 class="post-subtitle">
             {{ post.subtitle }}
         </h3>
         {% endif %}
-    </a>
     {{ post.excerpt }}
     {% capture content_words %}
       {{ post.content | number_of_words }}

--- a/css/2015-tc.css
+++ b/css/2015-tc.css
@@ -204,3 +204,8 @@ blockquote {
   margin-left: 40px;
   margin-right: 120px;
 }
+
+.jumbotron {
+  background-color: #000000;
+  margin-bottom: 0;
+}


### PR DESCRIPTION
While going through steps of getting the blog set up for ourselves, we
made a short list of changes that immediately caught our eye.

* Moved banner to be inside the header, and removed the bottom-margin.
* Get rid of extra "Blog" link in nav
* Update subtitle copy
* Fix links to be inside headings

For now, fixing pagination by upping the pagination limit. In the future
it would be nice to possibly hardcode the link to the blog instead of
dynamically creating it, so we don't have to worry about how many posts
there are.

Links are inline elements and should not wrap block elements, so we
fixed that.

Other small layout tweaks to fix margins.

Before:

![Screen Shot 2019-05-29 at 3 21 11 PM](https://user-images.githubusercontent.com/36161/58588913-5c467400-8226-11e9-99df-ccb9f7c50fed.png)

After:

![Screen Shot 2019-05-29 at 3 21 43 PM](https://user-images.githubusercontent.com/36161/58588923-623c5500-8226-11e9-91ae-432098348a8d.png)

Co-authored-by: Brittany Greaner <grea0022@umn.edu>
Co-authored-by: Tony Thomas <thoma127@umn.edu>